### PR TITLE
Lazy init, don't access Telegram object on module level

### DIFF
--- a/src/composables/useWebApp.ts
+++ b/src/composables/useWebApp.ts
@@ -1,16 +1,6 @@
 import { onMounted, onUnmounted, readonly, ref } from "vue"
 import { OnEventOptions, OnEventWithOptions } from "~/types"
 
-const {
-  initData,
-  initDataUnsafe,
-  version,
-  platform,
-  isVersionAtLeast,
-  sendData,
-  close,
-} = Telegram.WebApp
-
 const isReady = ref(false)
 
 const ready: typeof Telegram.WebApp.ready = (...params) => {
@@ -32,8 +22,6 @@ const isPlatform = (
     | "unigram",
 ) => Telegram.WebApp.platform === name
 
-const isPlatformUnknown = isPlatform("unknown")
-
 const featureSupportVersion = {
   ClosingConfirmation: "6.2",
   CloudStorage: "6.9",
@@ -44,10 +32,8 @@ const featureSupportVersion = {
   DisableVerticalSwipes: "7.7",
 }
 const isFeatureSupported = (name: keyof typeof featureSupportVersion) => {
-  return isVersionAtLeast(featureSupportVersion[name])
+  return Telegram.WebApp.isVersionAtLeast(featureSupportVersion[name])
 }
-
-const canSendData = !isPlatformUnknown && Telegram.WebApp.initData === ""
 
 export function useWebApp() {
   const onEvent: OnEventWithOptions<OnEventOptions> = (
@@ -83,6 +69,20 @@ export function useWebApp() {
       off,
     }
   }
+
+  const {
+    initData,
+    initDataUnsafe,
+    version,
+    platform,
+    isVersionAtLeast,
+    sendData,
+    close,
+  } = Telegram.WebApp
+
+  const isPlatformUnknown = isPlatform("unknown")
+
+  const canSendData = !isPlatformUnknown && initData === ""
 
   return {
     initData,

--- a/src/composables/useWebAppBackButton.ts
+++ b/src/composables/useWebAppBackButton.ts
@@ -1,28 +1,35 @@
 import { computed, ref } from "vue"
+import { defineStore } from "../utils"
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const isBackButtonVisible = ref(Telegram.WebApp.BackButton.isVisible)
+const useStore = defineStore(() => {
+  const isBackButtonVisible = ref(Telegram.WebApp.BackButton.isVisible)
 
-function updateState() {
-  isBackButtonVisible.value = Telegram.WebApp.BackButton.isVisible
-}
+  function updateState() {
+    isBackButtonVisible.value = Telegram.WebApp.BackButton.isVisible
+  }
 
-function showBackButton(
-  ...params: Parameters<typeof Telegram.WebApp.BackButton.show>
-) {
-  Telegram.WebApp.BackButton.show(...params)
-  updateState()
-}
+  function showBackButton(
+    ...params: Parameters<typeof Telegram.WebApp.BackButton.show>
+  ) {
+    Telegram.WebApp.BackButton.show(...params)
+    updateState()
+  }
 
-function hideBackButton(
-  ...params: Parameters<typeof Telegram.WebApp.BackButton.hide>
-) {
-  Telegram.WebApp.BackButton.hide(...params)
-  updateState()
-}
+  function hideBackButton(
+    ...params: Parameters<typeof Telegram.WebApp.BackButton.hide>
+  ) {
+    Telegram.WebApp.BackButton.hide(...params)
+    updateState()
+  }
+
+  return { isBackButtonVisible, showBackButton, hideBackButton }
+})
 
 export function useWebAppBackButton() {
+  const { isBackButtonVisible, showBackButton, hideBackButton } = useStore()
+
   const { onEvent } = useWebApp()
 
   const onBackButtonClicked = (

--- a/src/composables/useWebAppBiometricManager.ts
+++ b/src/composables/useWebAppBiometricManager.ts
@@ -1,46 +1,63 @@
 import { readonly, ref } from "vue"
+import { defineStore } from "../utils"
 import { OnEventOptions } from "~/types"
 import { useWebApp } from "./useWebApp"
 
-const {
-  init,
-  requestAccess,
-  authenticate,
-  updateBiometricToken,
-  openSettings,
-} = Telegram.WebApp.BiometricManager
+const useStore = defineStore(() => {
+  const isBiometricInited = ref(Telegram.WebApp.BiometricManager.isInited)
+  const isBiometricAvailable = ref(
+    Telegram.WebApp.BiometricManager.isBiometricAvailable,
+  )
+  const biometricType = ref(Telegram.WebApp.BiometricManager.biometricType)
+  const isBiometricAccessRequested = ref(
+    Telegram.WebApp.BiometricManager.isAccessRequested,
+  )
+  const isBiometricAccessGranted = ref(
+    Telegram.WebApp.BiometricManager.isAccessGranted,
+  )
+  const isBiometricTokenSaved = ref(
+    Telegram.WebApp.BiometricManager.isAccessGranted,
+  )
+  const biometricDeviceId = ref(Telegram.WebApp.BiometricManager.deviceId)
 
-const isBiometricInited = ref(Telegram.WebApp.BiometricManager.isInited)
-const isBiometricAvailable = ref(
-  Telegram.WebApp.BiometricManager.isBiometricAvailable,
-)
-const biometricType = ref(Telegram.WebApp.BiometricManager.biometricType)
-const isBiometricAccessRequested = ref(
-  Telegram.WebApp.BiometricManager.isAccessRequested,
-)
-const isBiometricAccessGranted = ref(
-  Telegram.WebApp.BiometricManager.isAccessGranted,
-)
-const isBiometricTokenSaved = ref(
-  Telegram.WebApp.BiometricManager.isAccessGranted,
-)
-const biometricDeviceId = ref(Telegram.WebApp.BiometricManager.deviceId)
+  function updateState() {
+    isBiometricInited.value = Telegram.WebApp.BiometricManager.isInited
+    isBiometricAvailable.value =
+      Telegram.WebApp.BiometricManager.isBiometricAvailable
+    biometricType.value = Telegram.WebApp.BiometricManager.biometricType
+    isBiometricAccessRequested.value =
+      Telegram.WebApp.BiometricManager.isAccessRequested
+    isBiometricAccessGranted.value =
+      Telegram.WebApp.BiometricManager.isAccessGranted
+    biometricDeviceId.value = Telegram.WebApp.BiometricManager.deviceId
+    isBiometricTokenSaved.value =
+      Telegram.WebApp.BiometricManager.isBiometricTokenSaved
+  }
 
-function updateState() {
-  isBiometricInited.value = Telegram.WebApp.BiometricManager.isInited
-  isBiometricAvailable.value =
-    Telegram.WebApp.BiometricManager.isBiometricAvailable
-  biometricType.value = Telegram.WebApp.BiometricManager.biometricType
-  isBiometricAccessRequested.value =
-    Telegram.WebApp.BiometricManager.isAccessRequested
-  isBiometricAccessGranted.value =
-    Telegram.WebApp.BiometricManager.isAccessGranted
-  biometricDeviceId.value = Telegram.WebApp.BiometricManager.deviceId
-  isBiometricTokenSaved.value =
-    Telegram.WebApp.BiometricManager.isBiometricTokenSaved
-}
+  return {
+    isBiometricInited,
+    isBiometricAvailable,
+    biometricType,
+    isBiometricAccessRequested,
+    isBiometricAccessGranted,
+    biometricDeviceId,
+    isBiometricTokenSaved,
+    updateState,
+  }
+})
 
 export function useWebAppBiometricManager() {
+  const {
+    isBiometricInited,
+    isBiometricAvailable,
+    biometricType,
+    isBiometricAccessRequested,
+    isBiometricAccessGranted,
+    biometricDeviceId,
+    isBiometricTokenSaved,
+    updateState,
+  } = useStore()
+
   const { onEvent } = useWebApp()
 
   const onBiometricManagerUpdated = (
@@ -57,6 +74,14 @@ export function useWebAppBiometricManager() {
   ) => onEvent("biometricTokenUpdated", eventHandler, options)
 
   onBiometricManagerUpdated(updateState)
+
+  const {
+    init,
+    requestAccess,
+    authenticate,
+    updateBiometricToken,
+    openSettings,
+  } = Telegram.WebApp.BiometricManager
 
   return {
     isBiometricInited: readonly(isBiometricInited),

--- a/src/composables/useWebAppClipboard.ts
+++ b/src/composables/useWebAppClipboard.ts
@@ -1,8 +1,6 @@
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const { readTextFromClipboard } = Telegram.WebApp
-
 export function useWebAppClipboard() {
   const { onEvent } = useWebApp()
 
@@ -10,6 +8,8 @@ export function useWebAppClipboard() {
     eventHandler: ClipboardTextReceivedCallback,
     options?: OnEventOptions,
   ) => onEvent("clipboardTextReceived", eventHandler, options)
+
+  const { readTextFromClipboard } = Telegram.WebApp
 
   return {
     readTextFromClipboard,

--- a/src/composables/useWebAppClosingConfirmation.ts
+++ b/src/composables/useWebAppClosingConfirmation.ts
@@ -1,29 +1,45 @@
 import { computed, ref } from "vue"
+import { defineStore } from "../utils"
 
-const isClosingConfirmationEnabled = ref(
-  Telegram.WebApp.isClosingConfirmationEnabled,
-)
+const useStore = defineStore(() => {
+  const isClosingConfirmationEnabled = ref(
+    Telegram.WebApp.isClosingConfirmationEnabled,
+  )
 
-function updateStatus() {
-  isClosingConfirmationEnabled.value =
-    Telegram.WebApp.isClosingConfirmationEnabled
-}
+  function updateStatus() {
+    isClosingConfirmationEnabled.value =
+      Telegram.WebApp.isClosingConfirmationEnabled
+  }
 
-function enableClosingConfirmation(
-  ...params: Parameters<typeof Telegram.WebApp.enableClosingConfirmation>
-) {
-  Telegram.WebApp.enableClosingConfirmation(...params)
-  updateStatus()
-}
+  function enableClosingConfirmation(
+    ...params: Parameters<typeof Telegram.WebApp.enableClosingConfirmation>
+  ) {
+    Telegram.WebApp.enableClosingConfirmation(...params)
+    updateStatus()
+  }
 
-function disableClosingConfirmation(
-  ...params: Parameters<typeof Telegram.WebApp.disableClosingConfirmation>
-) {
-  Telegram.WebApp.disableClosingConfirmation(...params)
-  updateStatus()
-}
+  function disableClosingConfirmation(
+    ...params: Parameters<typeof Telegram.WebApp.disableClosingConfirmation>
+  ) {
+    Telegram.WebApp.disableClosingConfirmation(...params)
+    updateStatus()
+  }
+
+  return {
+    isClosingConfirmationEnabled,
+    updateStatus,
+    enableClosingConfirmation,
+    disableClosingConfirmation,
+  }
+})
 
 export function useWebAppClosingConfirmation() {
+  const {
+    isClosingConfirmationEnabled,
+    enableClosingConfirmation,
+    disableClosingConfirmation,
+  } = useStore()
+
   return {
     isClosingConfirmationEnabled: computed({
       get() {

--- a/src/composables/useWebAppCloudStorage.ts
+++ b/src/composables/useWebAppCloudStorage.ts
@@ -1,12 +1,12 @@
-const CloudStorage = Telegram.WebApp.CloudStorage
-
 type SetItemResult = Parameters<
-  NonNullable<NonNullable<Parameters<typeof CloudStorage.setItem>>[2]>
+  NonNullable<
+    NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.setItem>>[2]
+  >
 >[1]
 
 function setStorageItem(key: string, value: string) {
   return new Promise<SetItemResult>((resolve, reject) => {
-    CloudStorage.setItem(key, value, (error, ok) => {
+    Telegram.WebApp.CloudStorage.setItem(key, value, (error, ok) => {
       if (error) reject(error)
 
       resolve(ok)
@@ -15,12 +15,14 @@ function setStorageItem(key: string, value: string) {
 }
 
 type GetItemResult = Parameters<
-  NonNullable<NonNullable<Parameters<typeof CloudStorage.getItem>>[1]>
+  NonNullable<
+    NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.getItem>>[1]
+  >
 >[1]
 
 function getStorageItem(key: string) {
   return new Promise<GetItemResult>((resolve, reject) => {
-    CloudStorage.getItem(key, (error, value) => {
+    Telegram.WebApp.CloudStorage.getItem(key, (error, value) => {
       if (error) reject(error)
 
       resolve(value)
@@ -30,13 +32,15 @@ function getStorageItem(key: string) {
 
 type GetItemsResult = NonNullable<
   Parameters<
-    NonNullable<NonNullable<Parameters<typeof CloudStorage.getItems>>[1]>
+    NonNullable<
+      NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.getItems>>[1]
+    >
   >[1]
 >
 
 function getStorageItems(keys: string[]) {
   return new Promise<GetItemsResult>((resolve, reject) => {
-    CloudStorage.getItems(keys, (error, values) => {
+    Telegram.WebApp.CloudStorage.getItems(keys, (error, values) => {
       if (error) reject(error)
 
       resolve(values as GetItemsResult)
@@ -45,12 +49,14 @@ function getStorageItems(keys: string[]) {
 }
 
 type RemoveItemResult = Parameters<
-  NonNullable<NonNullable<Parameters<typeof CloudStorage.removeItem>>[1]>
+  NonNullable<
+    NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.removeItem>>[1]
+  >
 >[1]
 
 function removeStorageItem(key: string) {
   return new Promise<RemoveItemResult>((resolve, reject) => {
-    CloudStorage.removeItem(key, (error, ok) => {
+    Telegram.WebApp.CloudStorage.removeItem(key, (error, ok) => {
       if (error) reject(error)
 
       resolve(ok)
@@ -59,12 +65,14 @@ function removeStorageItem(key: string) {
 }
 
 type RemoveItemsResult = Parameters<
-  NonNullable<NonNullable<Parameters<typeof CloudStorage.removeItems>>[1]>
+  NonNullable<
+    NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.removeItems>>[1]
+  >
 >[1]
 
 function removeStorageItems(keys: string[]) {
   return new Promise<RemoveItemsResult>((resolve, reject) => {
-    CloudStorage.removeItems(keys, (error, ok) => {
+    Telegram.WebApp.CloudStorage.removeItems(keys, (error, ok) => {
       if (error) reject(error)
 
       resolve(ok)
@@ -74,13 +82,15 @@ function removeStorageItems(keys: string[]) {
 
 type GetKeysResult = NonNullable<
   Parameters<
-    NonNullable<NonNullable<Parameters<typeof CloudStorage.getKeys>>[0]>
+    NonNullable<
+      NonNullable<Parameters<typeof Telegram.WebApp.CloudStorage.getKeys>>[0]
+    >
   >[1]
 >
 
 function getStorageKeys() {
   return new Promise<GetKeysResult>((resolve, reject) => {
-    CloudStorage.getKeys((error, values) => {
+    Telegram.WebApp.CloudStorage.getKeys((error, values) => {
       if (error) reject(error)
 
       resolve(values as GetKeysResult)

--- a/src/composables/useWebAppHapticFeedback.ts
+++ b/src/composables/useWebAppHapticFeedback.ts
@@ -1,7 +1,7 @@
-const { impactOccurred, notificationOccurred, selectionChanged } =
-  Telegram.WebApp.HapticFeedback
-
 export function useWebAppHapticFeedback() {
+  const { impactOccurred, notificationOccurred, selectionChanged } =
+    Telegram.WebApp.HapticFeedback
+
   return {
     impactOccurred,
     notificationOccurred,

--- a/src/composables/useWebAppMainButton.ts
+++ b/src/composables/useWebAppMainButton.ts
@@ -1,83 +1,120 @@
 import { computed, ref } from "vue"
+import { defineStore } from "../utils"
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const mainButtonText = ref(Telegram.WebApp.MainButton.text)
-const mainButtonColor = ref(Telegram.WebApp.MainButton.color)
-const mainButtonTextColor = ref(Telegram.WebApp.MainButton.textColor)
-const isMainButtonVisible = ref(Telegram.WebApp.MainButton.isVisible)
-const isMainButtonActive = ref(Telegram.WebApp.MainButton.isActive)
-const isMainButtonProgressVisible = ref(
-  Telegram.WebApp.MainButton.isProgressVisible,
-)
+const useStore = defineStore(() => {
+  const mainButtonText = ref(Telegram.WebApp.MainButton.text)
+  const mainButtonColor = ref(Telegram.WebApp.MainButton.color)
+  const mainButtonTextColor = ref(Telegram.WebApp.MainButton.textColor)
+  const isMainButtonVisible = ref(Telegram.WebApp.MainButton.isVisible)
+  const isMainButtonActive = ref(Telegram.WebApp.MainButton.isActive)
+  const isMainButtonProgressVisible = ref(
+    Telegram.WebApp.MainButton.isProgressVisible,
+  )
 
-function updateState() {
-  mainButtonText.value = Telegram.WebApp.MainButton.text
-  mainButtonColor.value = Telegram.WebApp.MainButton.color
-  mainButtonTextColor.value = Telegram.WebApp.MainButton.textColor
-  isMainButtonVisible.value = Telegram.WebApp.MainButton.isVisible
-  isMainButtonActive.value = Telegram.WebApp.MainButton.isActive
-  isMainButtonProgressVisible.value =
-    Telegram.WebApp.MainButton.isProgressVisible
-}
+  function updateState() {
+    mainButtonText.value = Telegram.WebApp.MainButton.text
+    mainButtonColor.value = Telegram.WebApp.MainButton.color
+    mainButtonTextColor.value = Telegram.WebApp.MainButton.textColor
+    isMainButtonVisible.value = Telegram.WebApp.MainButton.isVisible
+    isMainButtonActive.value = Telegram.WebApp.MainButton.isActive
+    isMainButtonProgressVisible.value =
+      Telegram.WebApp.MainButton.isProgressVisible
+  }
 
-function setMainButtonText(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.setText>
-) {
-  Telegram.WebApp.MainButton.setText(...params)
-  updateState()
-}
+  function setMainButtonText(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.setText>
+  ) {
+    Telegram.WebApp.MainButton.setText(...params)
+    updateState()
+  }
 
-function showMainButton(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.show>
-) {
-  Telegram.WebApp.MainButton.show(...params)
-  updateState()
-}
+  function showMainButton(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.show>
+  ) {
+    Telegram.WebApp.MainButton.show(...params)
+    updateState()
+  }
 
-function hideMainButton(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.hide>
-) {
-  Telegram.WebApp.MainButton.hide(...params)
-  updateState()
-}
+  function hideMainButton(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.hide>
+  ) {
+    Telegram.WebApp.MainButton.hide(...params)
+    updateState()
+  }
 
-function enableMainButton(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.enable>
-) {
-  Telegram.WebApp.MainButton.enable(...params)
-  updateState()
-}
+  function enableMainButton(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.enable>
+  ) {
+    Telegram.WebApp.MainButton.enable(...params)
+    updateState()
+  }
 
-function disableMainButton(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.disable>
-) {
-  Telegram.WebApp.MainButton.disable(...params)
-  updateState()
-}
+  function disableMainButton(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.disable>
+  ) {
+    Telegram.WebApp.MainButton.disable(...params)
+    updateState()
+  }
 
-function showMainButtonProgress(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.showProgress>
-) {
-  Telegram.WebApp.MainButton.showProgress(...params)
-  updateState()
-}
+  function showMainButtonProgress(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.showProgress>
+  ) {
+    Telegram.WebApp.MainButton.showProgress(...params)
+    updateState()
+  }
 
-function hideMainButtonProgress(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.hideProgress>
-) {
-  Telegram.WebApp.MainButton.hideProgress(...params)
-  updateState()
-}
+  function hideMainButtonProgress(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.hideProgress>
+  ) {
+    Telegram.WebApp.MainButton.hideProgress(...params)
+    updateState()
+  }
 
-function setMainButtonParams(
-  ...params: Parameters<typeof Telegram.WebApp.MainButton.setParams>
-) {
-  Telegram.WebApp.MainButton.setParams(...params)
-  updateState()
-}
+  function setMainButtonParams(
+    ...params: Parameters<typeof Telegram.WebApp.MainButton.setParams>
+  ) {
+    Telegram.WebApp.MainButton.setParams(...params)
+    updateState()
+  }
+
+  return {
+    mainButtonText,
+    mainButtonColor,
+    mainButtonTextColor,
+    isMainButtonVisible,
+    isMainButtonActive,
+    isMainButtonProgressVisible,
+    setMainButtonText,
+    showMainButton,
+    hideMainButton,
+    enableMainButton,
+    disableMainButton,
+    showMainButtonProgress,
+    hideMainButtonProgress,
+    setMainButtonParams,
+  }
+})
 
 export function useWebAppMainButton() {
+  const {
+    mainButtonText,
+    mainButtonColor,
+    mainButtonTextColor,
+    isMainButtonVisible,
+    isMainButtonActive,
+    isMainButtonProgressVisible,
+    setMainButtonText,
+    showMainButton,
+    hideMainButton,
+    enableMainButton,
+    disableMainButton,
+    showMainButtonProgress,
+    hideMainButtonProgress,
+    setMainButtonParams,
+  } = useStore()
+
   const { onEvent } = useWebApp()
 
   const onMainButtonClicked = (

--- a/src/composables/useWebAppNavigation.ts
+++ b/src/composables/useWebAppNavigation.ts
@@ -1,9 +1,6 @@
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const { switchInlineQuery, openLink, openTelegramLink, openInvoice } =
-  Telegram.WebApp
-
 export function useWebAppNavigation() {
   const { onEvent } = useWebApp()
 
@@ -11,6 +8,9 @@ export function useWebAppNavigation() {
     eventHandler: InvoiceClosedCallback,
     options?: OnEventOptions,
   ) => onEvent("invoiceClosed", eventHandler, options)
+
+  const { switchInlineQuery, openLink, openTelegramLink, openInvoice } =
+    Telegram.WebApp
 
   return {
     switchInlineQuery,

--- a/src/composables/useWebAppPopup.ts
+++ b/src/composables/useWebAppPopup.ts
@@ -1,8 +1,6 @@
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const { showPopup, showAlert, showConfirm } = Telegram.WebApp
-
 export function useWebAppPopup() {
   const { onEvent } = useWebApp()
 
@@ -10,6 +8,8 @@ export function useWebAppPopup() {
     eventHandler: PopupClosedCallback,
     options?: OnEventOptions,
   ) => onEvent("popupClosed", eventHandler, options)
+
+  const { showPopup, showAlert, showConfirm } = Telegram.WebApp
 
   return {
     showPopup,

--- a/src/composables/useWebAppQrScanner.ts
+++ b/src/composables/useWebAppQrScanner.ts
@@ -1,8 +1,6 @@
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const { showScanQrPopup, closeScanQrPopup } = Telegram.WebApp
-
 export function useWebAppQrScanner() {
   const { onEvent } = useWebApp()
 
@@ -15,6 +13,8 @@ export function useWebAppQrScanner() {
     eventHandler: ScanQrPopupClosedCallback,
     options?: OnEventOptions,
   ) => onEvent("scanQrPopupClosed", eventHandler, options)
+
+  const { showScanQrPopup, closeScanQrPopup } = Telegram.WebApp
 
   return {
     showScanQrPopup,

--- a/src/composables/useWebAppRequests.ts
+++ b/src/composables/useWebAppRequests.ts
@@ -1,8 +1,6 @@
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const { requestContact, requestWriteAccess } = Telegram.WebApp
-
 export function useWebAppRequests() {
   const { onEvent } = useWebApp()
 
@@ -15,6 +13,8 @@ export function useWebAppRequests() {
     eventHandler: ContactRequestedCallback,
     options?: OnEventOptions,
   ) => onEvent("contactRequested", eventHandler, options)
+
+  const { requestContact, requestWriteAccess } = Telegram.WebApp
 
   return {
     requestContact,

--- a/src/composables/useWebAppSendData.ts
+++ b/src/composables/useWebAppSendData.ts
@@ -1,8 +1,6 @@
 import { ref } from "vue"
 import { useWebApp } from "./useWebApp"
 
-const { initData, initDataUnsafe, sendData, close } = useWebApp()
-
 /**
  * @deprecated
  */
@@ -21,6 +19,8 @@ export function useWebAppSendData<D>(
   }
 
   const isLoading = ref(false)
+
+  const { initData, initDataUnsafe, sendData, close } = useWebApp()
 
   return {
     error,

--- a/src/composables/useWebAppSettingsButton.ts
+++ b/src/composables/useWebAppSettingsButton.ts
@@ -1,28 +1,36 @@
 import { computed, ref } from "vue"
+import { defineStore } from "../utils"
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const isSettingsButtonVisible = ref(Telegram.WebApp.SettingsButton.isVisible)
+const useStore = defineStore(() => {
+  const isSettingsButtonVisible = ref(Telegram.WebApp.SettingsButton.isVisible)
 
-function updateState() {
-  isSettingsButtonVisible.value = Telegram.WebApp.SettingsButton.isVisible
-}
+  function showSettingsButton(
+    ...params: Parameters<typeof Telegram.WebApp.SettingsButton.show>
+  ) {
+    Telegram.WebApp.SettingsButton.show(...params)
+    isSettingsButtonVisible.value = true
+  }
 
-function showSettingsButton(
-  ...params: Parameters<typeof Telegram.WebApp.SettingsButton.show>
-) {
-  Telegram.WebApp.SettingsButton.show(...params)
-  updateState()
-}
+  function hideSettingsButton(
+    ...params: Parameters<typeof Telegram.WebApp.SettingsButton.hide>
+  ) {
+    Telegram.WebApp.SettingsButton.hide(...params)
+    isSettingsButtonVisible.value = false
+  }
 
-function hideSettingsButton(
-  ...params: Parameters<typeof Telegram.WebApp.SettingsButton.hide>
-) {
-  Telegram.WebApp.SettingsButton.hide(...params)
-  updateState()
-}
+  return {
+    isSettingsButtonVisible,
+    showSettingsButton,
+    hideSettingsButton,
+  }
+})
 
 export function useWebAppSettingsButton() {
+  const { isSettingsButtonVisible, showSettingsButton, hideSettingsButton } =
+    useStore()
+
   const { onEvent } = useWebApp()
 
   const onSettingsButtonClicked = (

--- a/src/composables/useWebAppTheme.ts
+++ b/src/composables/useWebAppTheme.ts
@@ -1,36 +1,59 @@
 import { computed, readonly, ref } from "vue"
+import { defineStore } from "../utils"
 import { useWebApp } from "./useWebApp"
 import { OnEventOptions } from "~/types"
 
-const colorScheme = ref(Telegram.WebApp.colorScheme)
-const themeParams = ref(Telegram.WebApp.themeParams)
-const headerColor = ref(Telegram.WebApp.headerColor)
-const backgroundColor = ref(Telegram.WebApp.backgroundColor)
+const useStore = defineStore(() => {
+  const colorScheme = ref(Telegram.WebApp.colorScheme)
+  const themeParams = ref(Telegram.WebApp.themeParams)
+  const headerColor = ref(Telegram.WebApp.headerColor)
+  const backgroundColor = ref(Telegram.WebApp.backgroundColor)
 
-function updateState() {
-  colorScheme.value = Telegram.WebApp.colorScheme
-  themeParams.value = {
-    ...Telegram.WebApp.themeParams,
+  function updateState() {
+    colorScheme.value = Telegram.WebApp.colorScheme
+    themeParams.value = {
+      ...Telegram.WebApp.themeParams,
+    }
+    headerColor.value = Telegram.WebApp.headerColor
+    backgroundColor.value = Telegram.WebApp.backgroundColor
   }
-  headerColor.value = Telegram.WebApp.headerColor
-  backgroundColor.value = Telegram.WebApp.backgroundColor
-}
 
-function setHeaderColor(
-  ...params: Parameters<typeof Telegram.WebApp.setHeaderColor>
-) {
-  Telegram.WebApp.setHeaderColor(...params)
-  updateState()
-}
+  function setHeaderColor(
+    ...params: Parameters<typeof Telegram.WebApp.setHeaderColor>
+  ) {
+    Telegram.WebApp.setHeaderColor(...params)
+    updateState()
+  }
 
-function setBackgroundColor(
-  ...params: Parameters<typeof Telegram.WebApp.setBackgroundColor>
-) {
-  Telegram.WebApp.setBackgroundColor(...params)
-  updateState()
-}
+  function setBackgroundColor(
+    ...params: Parameters<typeof Telegram.WebApp.setBackgroundColor>
+  ) {
+    Telegram.WebApp.setBackgroundColor(...params)
+    updateState()
+  }
+
+  return {
+    colorScheme,
+    themeParams,
+    headerColor,
+    backgroundColor,
+    updateState,
+    setHeaderColor,
+    setBackgroundColor,
+  }
+})
 
 export function useWebAppTheme() {
+  const {
+    colorScheme,
+    themeParams,
+    headerColor,
+    backgroundColor,
+    updateState,
+    setHeaderColor,
+    setBackgroundColor,
+  } = useStore()
+
   const { onEvent } = useWebApp()
 
   const onThemeChanged = (eventHandler: () => void, options?: OnEventOptions) =>

--- a/src/composables/useWebAppViewport.ts
+++ b/src/composables/useWebAppViewport.ts
@@ -1,39 +1,64 @@
 import { computed, readonly, ref } from "vue"
+import { defineStore } from "../utils"
 import { useWebApp } from "./useWebApp"
 import type { OnEventOptions } from "~/types"
 
-const isExpanded = ref(Telegram.WebApp.isExpanded)
-const viewportHeight = ref(Telegram.WebApp.viewportHeight)
-const viewportStableHeight = ref(Telegram.WebApp.viewportStableHeight)
-const isVerticalSwipesEnabled = ref(Telegram.WebApp.isVerticalSwipesEnabled)
+const useStore = defineStore(() => {
+  const isExpanded = ref(Telegram.WebApp.isExpanded)
+  const viewportHeight = ref(Telegram.WebApp.viewportHeight)
+  const viewportStableHeight = ref(Telegram.WebApp.viewportStableHeight)
+  const isVerticalSwipesEnabled = ref(Telegram.WebApp.isVerticalSwipesEnabled)
 
-function updateState() {
-  isExpanded.value = Telegram.WebApp.isExpanded
-  viewportHeight.value = Telegram.WebApp.viewportHeight
-  viewportStableHeight.value = Telegram.WebApp.viewportStableHeight
-  isVerticalSwipesEnabled.value = Telegram.WebApp.isVerticalSwipesEnabled
-}
+  function updateState() {
+    isExpanded.value = Telegram.WebApp.isExpanded
+    viewportHeight.value = Telegram.WebApp.viewportHeight
+    viewportStableHeight.value = Telegram.WebApp.viewportStableHeight
+    isVerticalSwipesEnabled.value = Telegram.WebApp.isVerticalSwipesEnabled
+  }
 
-function expand(...params: Parameters<typeof Telegram.WebApp.expand>) {
-  Telegram.WebApp.expand(...params)
-  updateState()
-}
+  function expand(...params: Parameters<typeof Telegram.WebApp.expand>) {
+    Telegram.WebApp.expand(...params)
+    updateState()
+  }
 
-const enableVerticalSwipes: typeof Telegram.WebApp.enableVerticalSwipes = (
-  ...params
-) => {
-  Telegram.WebApp.enableVerticalSwipes(...params)
-  updateState()
-}
+  const enableVerticalSwipes: typeof Telegram.WebApp.enableVerticalSwipes = (
+    ...params
+  ) => {
+    Telegram.WebApp.enableVerticalSwipes(...params)
+    updateState()
+  }
 
-const disableVerticalSwipes: typeof Telegram.WebApp.disableVerticalSwipes = (
-  ...params
-) => {
-  Telegram.WebApp.disableVerticalSwipes(...params)
-  updateState()
-}
+  const disableVerticalSwipes: typeof Telegram.WebApp.disableVerticalSwipes = (
+    ...params
+  ) => {
+    Telegram.WebApp.disableVerticalSwipes(...params)
+    updateState()
+  }
+
+  return {
+    isExpanded,
+    viewportHeight,
+    viewportStableHeight,
+    isVerticalSwipesEnabled,
+    updateState,
+    expand,
+    enableVerticalSwipes,
+    disableVerticalSwipes,
+  }
+})
 
 export function useWebAppViewport() {
+  const {
+    isExpanded,
+    viewportHeight,
+    viewportStableHeight,
+    isVerticalSwipesEnabled,
+    updateState,
+    expand,
+    enableVerticalSwipes,
+    disableVerticalSwipes,
+  } = useStore()
+
   const { onEvent } = useWebApp()
 
   const onViewportChanged = (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./store"

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,0 +1,20 @@
+import { effectScope } from "vue"
+
+/**
+ * Create a composable that returns a lazily initialized store.
+ */
+export function defineStore<T>(initialValue: () => T) {
+  let initialized = false
+  let value: T
+
+  return function useStore(): T {
+    if (!initialized) {
+      // Init store in detached scope, so that watchers are not disposed on component unmount.
+      effectScope(true).run(() => {
+        value = initialValue()
+      })
+      initialized = true
+    }
+    return value
+  }
+}


### PR DESCRIPTION
Remove top-level `Telegram.WebApp` access, allow importing this module without already-existing `telegram-web-app.js`.

Fix #38, probably also fix #9.

- [x] Remove global imports such as `const { initData } = Telegram.WebApp`
- [x] Remove global refs such as `const mainButtonText = ref(Telegram.WebApp.MainButton.text)`

With this update, one can _import_ composables such as `import { useWebApp } from "vue-tg"` freely without side effects. It's still not possible to _call_ them, however (which is a pity, but still better than nothing).